### PR TITLE
READMEのインストール案内修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Linux:
 curl -s https://raw.githubusercontent.com/MirrgieRiana/fluorite12/release/install.sh | sudo bash
 ```
 
-Download the `flc` binary to the `./fluorite12`, and register it in `/usr/local/bin`.
+Download the `flc` binary to `./fluorite12` and register it in `/usr/local/bin`.
 
 # DOCUMENTATION
 


### PR DESCRIPTION
## Summary
- README 65 行目の文言を修正して、インストール手順を明確化

## Testing
- `JAVA_HOME=./openjdk17/jdk bash gradlew jvmTest` *(fails: invalid directory)*

------
https://chatgpt.com/codex/tasks/task_e_68410fa443f883289f76da00550e326c