### PR TITLE
Add RANDOM builtin function

### DIFF
--- a/doc/ja/BUILTIN.md
+++ b/doc/ja/BUILTIN.md
@@ -63,6 +63,36 @@ $ flc 'SQRT(100.0)'
 # 10.0
 ```
 
+## `RANDOM` 乱数の取得
+
+`RANDOM(): NUMBER`
+
+`RANDOM(until: NUMBER): INTEGER`
+
+`RANDOM(from: NUMBER; until: NUMBER): INTEGER`
+
+引数の数によって返される値の範囲が変化します。
+
+* 引数なし: 0以上1未満の小数を返します。
+* 1引数: 0以上`until`未満の整数を返します。
+* 2引数: `from`以上`until`未満の整数を返します。
+
+```shell
+$ flc 'RANDOM()'
+# 0.123456
+```
+
+```shell
+$ flc 'RANDOM(10)'
+# 3
+```
+
+```shell
+$ flc 'RANDOM(5; 10)'
+# 7
+```
+
+
 # ストリーム系関数
 
 ## `REVERSE` ストリームを逆順にする

--- a/doc/ja/BUILTIN.md
+++ b/doc/ja/BUILTIN.md
@@ -65,33 +65,15 @@ $ flc 'SQRT(100.0)'
 
 ## `RANDOM` 乱数の取得
 
-`RANDOM(): NUMBER`
+`RANDOM(): DOUBLE`
 
-`RANDOM(until: NUMBER): INTEGER`
+`RANDOM([from: NUMBER; ]until: NUMBER): INT`
 
-`RANDOM(from: NUMBER; until: NUMBER): INTEGER`
+引数なしで呼び出された場合、0以上1未満の小数を返します。
 
-引数の数によって返される値の範囲が変化します。
+1引数で呼び出された場合、0以上 `until` 未満の整数を返します。
 
-* 引数なし: 0以上1未満の小数を返します。
-* 1引数: 0以上`until`未満の整数を返します。
-* 2引数: `from`以上`until`未満の整数を返します。
-
-```shell
-$ flc 'RANDOM()'
-# 0.123456
-```
-
-```shell
-$ flc 'RANDOM(10)'
-# 3
-```
-
-```shell
-$ flc 'RANDOM(5; 10)'
-# 7
-```
-
+2引数で呼び出された場合、`from` 以上 `until` 未満の整数を返します。
 
 # ストリーム系関数
 

--- a/src/commonMain/kotlin/mirrg/fluorite12/mounts/CommonMount.kt
+++ b/src/commonMain/kotlin/mirrg/fluorite12/mounts/CommonMount.kt
@@ -77,20 +77,24 @@ fun createCommonMount(): Map<String, FluoriteValue> {
         },
         "RANDOM" to FluoriteFunction { arguments ->
             when (arguments.size) {
-                0 -> FluoriteDouble(Random.nextDouble())
+                0 -> {
+                    FluoriteDouble(Random.nextDouble())
+                }
+
                 1 -> {
                     val until = arguments[0].toFluoriteNumber().toInt()
                     FluoriteInt(Random.nextInt(until))
                 }
+
                 2 -> {
                     val from = arguments[0].toFluoriteNumber().toInt()
                     val until = arguments[1].toFluoriteNumber().toInt()
                     FluoriteInt(Random.nextInt(from, until))
                 }
+
                 else -> usage(
                     "RANDOM(): DOUBLE",
-                    "RANDOM(until: NUMBER): INTEGER",
-                    "RANDOM(from: NUMBER; until: NUMBER): INTEGER",
+                    "RANDOM([from: NUMBER; ]until: NUMBER): INT",
                 )
             }
         },

--- a/src/commonMain/kotlin/mirrg/fluorite12/mounts/CommonMount.kt
+++ b/src/commonMain/kotlin/mirrg/fluorite12/mounts/CommonMount.kt
@@ -26,6 +26,7 @@ import kotlin.math.E
 import kotlin.math.PI
 import kotlin.math.floor
 import kotlin.math.sqrt
+import kotlin.random.Random
 
 private fun usage(vararg usages: String): Nothing = throw IllegalArgumentException(listOf("Usage:", *usages.map { "  $it" }.toTypedArray()).joinToString("\n"))
 
@@ -72,6 +73,25 @@ fun createCommonMount(): Map<String, FluoriteValue> {
             when (arguments.size) {
                 1 -> FluoriteDouble(sqrt((arguments[0] as FluoriteNumber).toDouble()))
                 else -> usage("SQRT(number: NUMBER): NUMBER")
+            }
+        },
+        "RANDOM" to FluoriteFunction { arguments ->
+            when (arguments.size) {
+                0 -> FluoriteDouble(Random.nextDouble())
+                1 -> {
+                    val until = arguments[0].toFluoriteNumber().toInt()
+                    FluoriteInt(Random.nextInt(until))
+                }
+                2 -> {
+                    val from = arguments[0].toFluoriteNumber().toInt()
+                    val until = arguments[1].toFluoriteNumber().toInt()
+                    FluoriteInt(Random.nextInt(from, until))
+                }
+                else -> usage(
+                    "RANDOM(): DOUBLE",
+                    "RANDOM(until: NUMBER): INTEGER",
+                    "RANDOM(from: NUMBER; until: NUMBER): INTEGER",
+                )
             }
         },
         "TO_ARRAY" to FluoriteFunction { arguments ->

--- a/src/commonTest/kotlin/Fluorite12Test.kt
+++ b/src/commonTest/kotlin/Fluorite12Test.kt
@@ -1,7 +1,9 @@
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import mirrg.fluorite12.Evaluator
+import mirrg.fluorite12.compilers.objects.FluoriteInt
 import mirrg.fluorite12.compilers.objects.FluoriteNull
+import mirrg.fluorite12.compilers.objects.invoke
 import mirrg.fluorite12.mounts.createCommonMount
 import mirrg.fluorite12.operations.FluoriteException
 import kotlin.test.Test
@@ -870,14 +872,20 @@ class Fluorite12Test {
 
     @Test
     fun randomFunctionTest() = runTest {
-        val d = eval("RANDOM()").double
-        assertTrue(d >= 0.0 && d < 1.0)
+        val random = eval("RANDOM")
 
-        val i1 = eval("RANDOM(10)").int
-        assertTrue(i1 >= 0 && i1 < 10)
-
-        val i2 = eval("RANDOM(5; 10)").int
-        assertTrue(i2 >= 5 && i2 < 10)
+        repeat(100) {
+            val d = random.invoke(arrayOf()).double
+            assertTrue(d >= 0.0 && d < 1.0)
+        }
+        repeat(100) {
+            val i = random.invoke(arrayOf(FluoriteInt(4))).int
+            assertTrue(i >= 0 && i < 4)
+        }
+        repeat(100) {
+            val i = random.invoke(arrayOf(FluoriteInt(4), FluoriteInt(10))).int
+            assertTrue(i >= 4 && i < 10)
+        }
     }
 
     @Test

--- a/src/commonTest/kotlin/Fluorite12Test.kt
+++ b/src/commonTest/kotlin/Fluorite12Test.kt
@@ -6,6 +6,7 @@ import mirrg.fluorite12.mounts.createCommonMount
 import mirrg.fluorite12.operations.FluoriteException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.fail
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -865,6 +866,18 @@ class Fluorite12Test {
         assertEquals(10, eval("FLOOR(10.1)").int) // FLOOR関数は小数点以下を切り捨てて内部的な型をINTEGERにする
         assertEquals(10, eval("FLOOR(10)").int) // 整数はそのまま
         assertEquals(-11, eval("FLOOR(-10.1)").int) // 負の数も値が小さくなるように切り捨てる
+    }
+
+    @Test
+    fun randomFunctionTest() = runTest {
+        val d = eval("RANDOM()").double
+        assertTrue(d >= 0.0 && d < 1.0)
+
+        val i1 = eval("RANDOM(10)").int
+        assertTrue(i1 >= 0 && i1 < 10)
+
+        val i2 = eval("RANDOM(5; 10)").int
+        assertTrue(i2 >= 5 && i2 < 10)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- RANDOM 関数を追加し、引数数に応じて乱数を返すよう実装
- RANDOM 関数のテストを追加
- BUILTIN ドキュメントに RANDOM の説明と使用例を追加

## Testing
- `JAVA_HOME=/workspace/fluorite12/openjdk17/jdk bash gradlew jvmTest --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6847bcca1fc48328a0df57025124cc2d