### PR TITLE
Add Unicode escape syntax

### DIFF
--- a/doc/ja/STRING.md
+++ b/doc/ja/STRING.md
@@ -56,6 +56,7 @@ $ flc \''abc$def\nop'\'
 | `\t`                  | タブ文字         |
 | `\r`                  | CR           |
 | `\n`                  | LF           |
+| `\uXXXX`             | 指定したUnicodeの1文字 |
 | 上記以外の ` \ ` で始まるシーケンス | 構文エラー        |
 | CRLF                  | LF           |
 | CR                    | LF           |
@@ -77,6 +78,13 @@ $ flc \''abc$def\nop'\'
 $ flc ' "abc\"def\\ghi\njkl" '
 # abc"def\ghi
 # jkl
+```
+
+Unicodeを指定するエスケープシーケンスも利用できます。
+
+```shell
+$ flc ' "\u3042" '
+# あ
 ```
 
 ## 改行コンテント

--- a/src/commonMain/kotlin/mirrg/fluorite12/Grammar.kt
+++ b/src/commonMain/kotlin/mirrg/fluorite12/Grammar.kt
@@ -161,6 +161,14 @@ class Fluorite12Grammar : Grammar<Node>() {
     val quotedIdentifierContent: Parser<Pair<List<TokenMatch>, String>> by OrCombinator(
         -NotParser(bQuote or bSlash or br) * AnyParser map { Pair(listOf(it), it.text) }, // ' \ 改行以外の文字
         br map { Pair(listOf(it), "\n") }, // 改行
+        bSlash * lU *
+            (number or lA or uA or lB or uB or lC or uC or lD or uD or lE or uE or lF or uF) *
+            (number or lA or uA or lB or uB or lC or uC or lD or uD or lE or uE or lF or uF) *
+            (number or lA or uA or lB or uB or lC or uC or lD or uD or lE or uE or lF or uF) *
+            (number or lA or uA or lB or uB or lC or uC or lD or uD or lE or uE or lF or uF) map {
+            val code = "" + it.t3.text + it.t4.text + it.t5.text + it.t6.text
+            Pair(listOf(it.t1, it.t2, it.t3, it.t4, it.t5, it.t6), code.toInt(16).toChar().toString())
+        },
         bSlash * -NotParser(br) * AnyParser map { Pair(listOf(it.t1, it.t2), it.t2.text) }, // エスケープされた改行以外の文字
         bSlash * br map { Pair(listOf(it.t1, it.t2), "\n") }, // エスケープされた改行
     )
@@ -198,6 +206,10 @@ class Fluorite12Grammar : Grammar<Node>() {
         bSlash * (lT) map { Pair(listOf(it.t1, it.t2), "\t") },
         bSlash * (lR) map { Pair(listOf(it.t1, it.t2), "\r") },
         bSlash * (lN) map { Pair(listOf(it.t1, it.t2), "\n") },
+        bSlash * lU * hexadecimalCharacter * hexadecimalCharacter * hexadecimalCharacter * hexadecimalCharacter map {
+            val code = "" + it.t3.text + it.t4.text + it.t5.text + it.t6.text
+            Pair(listOf(it.t1, it.t2, it.t3, it.t4, it.t5, it.t6), code.toInt(16).toChar().toString())
+        },
     )
     val formatterFlag by OrCombinator(
         minus map { Pair(it, FormatterFlag.LEFT_ALIGNED) },

--- a/src/commonTest/kotlin/Fluorite12Test.kt
+++ b/src/commonTest/kotlin/Fluorite12Test.kt
@@ -157,6 +157,7 @@ class Fluorite12Test {
         assertEquals("あ", eval(""" "あ" """).string) // マルチバイト文字
         assertEquals("㎡", eval(""" "㎡" """).string) // MS932
         assertEquals("🍰", eval(""" "🍰" """).string) // サロゲートペア
+        assertEquals("あ", eval("\"\\u3042\"").string) // Unicodeエスケープ
 
         assertEquals(""" " $ \ """, eval(""" " \" \$ \\ " """).string) // エスケープが必要な記号
         assertEquals(" \r \n \t ", eval(""" " \r \n \t " """).string) // 制御文字のエスケープ
@@ -1088,6 +1089,7 @@ class Fluorite12Test {
         assertEquals(123, eval("{`abc`: 123}.abc").int) // エントリーキーのクォート識別子
         assertEquals(123, eval("{abc: 123}.`abc`").int) // プロパティアクセスのクォート識別子
         assertEquals(123, eval("{abc: this -> 123}{}::`abc`()").int) // メソッドのクォート識別子
+        assertEquals(123, eval("`\\u3042` := 123; あ").int) // Unicodeエスケープ
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add `\uXXXX` escape to template strings and quoted identifiers
- document Unicode escapes
- test new escapes

## Testing
- `bash gradlew jvmTest --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_684a2870ee0083289f7e59552794da88